### PR TITLE
fix: remove trailing spaces from prompts

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -3,8 +3,8 @@ def divide_numbers(a, b):
 
 def main():
     print("Welcome to the calculator")
-    num1 = input("Enter the first number: ")
-    num2 = input("Enter the second number: ")
+    num1 = input("Enter the first number:")
+    num2 = input("Enter the second number:")
 
     result = divide_numbers(num1, num2)
     print("The result is:", result)


### PR DESCRIPTION
## Summary
- remove trailing spaces from prompt strings in `calculator.py`

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_b_686543389e04832aa161bdf7134d10c4